### PR TITLE
Restore progress and performance logs

### DIFF
--- a/doctr_mod/README.md
+++ b/doctr_mod/README.md
@@ -9,6 +9,7 @@ This project consolidates the previous DocTR_Mod and TicketSorter5 apps into a s
 - Multiple output handlers: CSV, Excel logs, vendor PDF/TIFF export, and SharePoint upload
 - Configurable via `config.yaml`, command line, or a simple GUI
 - Designed for integration into larger automation pipelines
+- Optional progress bars and performance logging
 
 ## Quick Start
 
@@ -26,6 +27,8 @@ This project consolidates the previous DocTR_Mod and TicketSorter5 apps into a s
    ```bash
    python doctr_ocr_to_csv.py
    ```
+   A performance report `performance_log.csv` will be generated when
+   `profile: true` is set in `config.yaml`.
 4. Or launch the graphical interface
    ```bash
    python gui.py
@@ -39,6 +42,7 @@ See `config.yaml` for all available options. Key settings include:
 - `ocr_engine` – `doctr`, `tesseract` or `easyocr`
 - `orientation_check` – rotate pages using Tesseract or Doctr
 - `sharepoint_config` – credentials and target folder if using SharePoint
+- `profile` – when true, write `performance_log.csv` and show progress bars
 
 ## Extending Outputs
 Additional output formats can be added by implementing the `OutputHandler` interface in `output/base.py` and registering it in `output/factory.py`.

--- a/doctr_mod/config.yaml
+++ b/doctr_mod/config.yaml
@@ -19,3 +19,4 @@ orientation_check: tesseract  # tesseract, doctr, or none
 vendor_keywords_csv: ./ocr_keywords.csv
 extraction_rules_yaml: ./extraction_rules.yaml
 poppler_path:
+profile: false

--- a/doctr_mod/docs/USER_GUIDE.md
+++ b/doctr_mod/docs/USER_GUIDE.md
@@ -85,6 +85,9 @@ num_workers: 4
 debug: false
 profile: false
 
+When `profile` is set to `true`, the program displays progress bars and
+records timing information for each file in `performance_log.csv`.
+
 `orientation_check` determines how page rotation is handled:
 - `tesseract` (default): use Tesseract's OSD to correct orientation
 - `doctr`: use Doctr's angle prediction model

--- a/doctr_mod/doctr_ocr_to_csv.py
+++ b/doctr_mod/doctr_ocr_to_csv.py
@@ -1,9 +1,17 @@
 """Unified OCR pipeline entry point."""
 
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Tuple
+import logging
+import time
+import csv
+import os
 
-from doctr_ocr.config_utils import load_config, load_extraction_rules
+from doctr_ocr.config_utils import (
+    load_config,
+    load_extraction_rules,
+    count_total_pages,
+)
 from doctr_ocr.input_picker import resolve_input
 from doctr_ocr.ocr_engine import get_engine
 from doctr_ocr.vendor_utils import (
@@ -12,26 +20,45 @@ from doctr_ocr.vendor_utils import (
     extract_vendor_fields,
 )
 from doctr_ocr.ocr_utils import extract_images_generator, correct_image_orientation
+from tqdm import tqdm
 from output.factory import create_handlers
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,%(levelname)s,%(message)s",
+    filename="error.log",
+)
 
-def process_file(pdf_path: str, cfg: dict, vendor_rules, extraction_rules) -> List[Dict]:
-    """Extract configured fields from ``pdf_path``.
 
-    Returns a list of dictionaries containing the extracted values and the
-    path to the saved page image.
-    """
+def process_file(
+    pdf_path: str, cfg: dict, vendor_rules, extraction_rules
+) -> Tuple[List[Dict], Dict]:
+    """Process ``pdf_path`` and return rows and performance stats."""
+
     engine = get_engine(cfg.get("ocr_engine", "doctr"))
     rows: List[Dict] = []
     orient_method = cfg.get("orientation_check", "tesseract")
-    for i, img in enumerate(extract_images_generator(pdf_path, cfg.get("poppler_path"))):
+    total_pages = count_total_pages([pdf_path], cfg)
+    start = time.perf_counter()
+
+    for i, img in enumerate(
+        tqdm(
+            extract_images_generator(pdf_path, cfg.get("poppler_path")),
+            total=total_pages,
+            desc=os.path.basename(pdf_path),
+            unit="page",
+        )
+    ):
         img = correct_image_orientation(img, i + 1, method=orient_method)
         text, result_page = engine(img)
-        vendor_name, vendor_type, matched = find_vendor(text, vendor_rules)
+        vendor_name, vendor_type, _ = find_vendor(text, vendor_rules)
         if result_page is not None:
             fields = extract_vendor_fields(result_page, vendor_name, extraction_rules)
         else:
-            fields = {f: None for f in ["ticket_number", "manifest_number", "material_type", "truck_number", "date"]}
+            fields = {
+                f: None
+                for f in ["ticket_number", "manifest_number", "material_type", "truck_number", "date"]
+            }
         row = {
             "file": pdf_path,
             "page": i + 1,
@@ -41,7 +68,14 @@ def process_file(pdf_path: str, cfg: dict, vendor_rules, extraction_rules) -> Li
             "ocr_text": text,
         }
         rows.append(row)
-    return rows
+
+    duration = time.perf_counter() - start
+    perf = {
+        "file": os.path.basename(pdf_path),
+        "pages": total_pages,
+        "duration_sec": round(duration, 2),
+    }
+    return rows, perf
 
 
 def save_page_image(img, pdf_path: str, idx: int, cfg: dict) -> str:
@@ -53,15 +87,32 @@ def save_page_image(img, pdf_path: str, idx: int, cfg: dict) -> str:
     return str(out_path)
 
 
+def _write_performance_log(records: List[Dict], cfg: dict) -> None:
+    """Save performance metrics to ``performance_log.csv`` in ``output_dir``."""
+    if not records:
+        return
+    out_dir = cfg.get("output_dir", "./outputs")
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, "performance_log.csv")
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["file", "pages", "duration_sec"])
+        writer.writeheader()
+        writer.writerows(records)
+    logging.info("Performance log written to %s", path)
+
+
 def run_pipeline():
     """Execute the OCR pipeline using ``config.yaml``."""
     cfg = load_config()
     cfg = resolve_input(cfg)
-    extraction_rules = load_extraction_rules(cfg.get("extraction_rules_yaml", "extraction_rules.yaml"))
-    vendor_rules = load_vendor_rules_from_csv(cfg.get("vendor_keywords_csv", "ocr_keywords.csv"))
+    extraction_rules = load_extraction_rules(
+        cfg.get("extraction_rules_yaml", "extraction_rules.yaml")
+    )
+    vendor_rules = load_vendor_rules_from_csv(
+        cfg.get("vendor_keywords_csv", "ocr_keywords.csv")
+    )
     output_handlers = create_handlers(cfg.get("output_format", ["csv"]), cfg)
 
-    files = []
     if cfg.get("batch_mode"):
         path = Path(cfg["input_dir"])
         files = sorted(str(p) for p in path.glob("*.pdf"))
@@ -69,11 +120,18 @@ def run_pipeline():
         files = [cfg["input_pdf"]]
 
     all_rows: List[Dict] = []
-    for f in files:
-        all_rows.extend(process_file(f, cfg, vendor_rules, extraction_rules))
+    perf_records: List[Dict] = []
+    for idx, f in enumerate(files, 1):
+        logging.info("Processing %s (%d/%d)", os.path.basename(f), idx, len(files))
+        rows, perf = process_file(f, cfg, vendor_rules, extraction_rules)
+        perf_records.append(perf)
+        all_rows.extend(rows)
 
     for handler in output_handlers:
         handler.write(all_rows, cfg)
+
+    if cfg.get("profile"):
+        _write_performance_log(perf_records, cfg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional progress bars and timing to pipeline
- log performance metrics when `profile: true`
- document new `profile` option and logging behavior

## Testing
- `python -m py_compile doctr_mod/doctr_ocr_to_csv.py`
- `python -m py_compile doctr_mod/output/csv_output.py doctr_mod/output/excel_output.py doctr_mod/output/factory.py doctr_mod/output/sharepoint_output.py doctr_mod/output/vendor_doc_output.py doctr_mod/doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c69b7dc88331b23ffbbd3ae96a0a