### PR TITLE
Integrate TicketSorter utilities & add combined PDF option

### DIFF
--- a/doctr_mod/README.md
+++ b/doctr_mod/README.md
@@ -39,6 +39,7 @@ See `config.yaml` for all available options. Key settings include:
 
 - `input_pdf` or `input_dir` – source file(s)
 - `output_format` – list of outputs (`csv`, `excel`, `vendor_pdf`, `vendor_tiff`, `sharepoint`)
+- `combined_pdf` – when true, merge vendor PDFs into a single file
 - `ocr_engine` – `doctr`, `tesseract` or `easyocr`
 - `orientation_check` – rotate pages using Tesseract or Doctr
 - `sharepoint_config` – credentials and target folder if using SharePoint

--- a/doctr_mod/config.yaml
+++ b/doctr_mod/config.yaml
@@ -4,6 +4,7 @@ input_pdf:
 input_dir:
 
 output_dir: ./outputs
+combined_pdf: false
 csv_filename: results.csv
 output_format: [csv, excel, vendor_pdf]
 sharepoint_config:

--- a/doctr_mod/gui.py
+++ b/doctr_mod/gui.py
@@ -40,6 +40,7 @@ def launch_gui() -> None:
     out_pdf = tk.BooleanVar(value="vendor_pdf" in cfg.get("output_format", []))
     out_tiff = tk.BooleanVar(value="vendor_tiff" in cfg.get("output_format", []))
     out_sp = tk.BooleanVar(value="sharepoint" in cfg.get("output_format", []))
+    combined_pdf_var = tk.BooleanVar(value=cfg.get("combined_pdf", False))
 
     status = tk.StringVar(value="")
 
@@ -86,6 +87,7 @@ def launch_gui() -> None:
         if out_sp.get():
             outputs.append("sharepoint")
         new_cfg["output_format"] = outputs
+        new_cfg["combined_pdf"] = combined_pdf_var.get()
 
         save_cfg(new_cfg)
         run_btn.config(state="disabled")
@@ -133,6 +135,7 @@ def launch_gui() -> None:
     tk.Checkbutton(fmt_frame, text="Vendor PDF", variable=out_pdf).grid(row=1, column=0, sticky="w")
     tk.Checkbutton(fmt_frame, text="Vendor TIFF", variable=out_tiff).grid(row=1, column=1, sticky="w")
     tk.Checkbutton(fmt_frame, text="SharePoint", variable=out_sp).grid(row=2, column=0, sticky="w")
+    tk.Checkbutton(fmt_frame, text="Combined PDF", variable=combined_pdf_var).grid(row=2, column=1, sticky="w")
 
     # Run button and status
     run_btn = tk.Button(root, text="Run Pipeline", command=run_clicked)

--- a/doctr_mod/output/vendor_doc_output.py
+++ b/doctr_mod/output/vendor_doc_output.py
@@ -2,8 +2,18 @@
 
 from typing import List, Dict, Any
 import os
+from pathlib import Path
 from PIL import Image
+from PyPDF2 import PdfMerger
+
 from .base import OutputHandler
+from processor.filename_utils import (
+    format_output_filename_camel,
+    format_output_filename,
+    format_output_filename_lower,
+    format_output_filename_snake,
+    parse_input_filename_fuzzy,
+)
 
 
 class VendorDocumentOutput(OutputHandler):
@@ -15,16 +25,45 @@ class VendorDocumentOutput(OutputHandler):
     def write(self, rows: List[Dict[str, Any]], cfg: dict) -> None:
         out_dir = os.path.join(cfg.get("output_dir", "./outputs"), "vendor_docs")
         os.makedirs(out_dir, exist_ok=True)
+
         vendor_map: Dict[str, List[str]] = {}
         for row in rows:
             vendor = row.get("vendor") or "unknown"
             vendor_map.setdefault(vendor, []).append(row.get("image_path"))
+
+        file_meta = None
+        if rows:
+            file_meta = parse_input_filename_fuzzy(rows[0].get("file", ""))
+
+        format_style = cfg.get("file_format", "camel").lower()
+        format_func = {
+            "camel": format_output_filename_camel,
+            "caps": format_output_filename,
+            "lower": format_output_filename_lower,
+            "snake": format_output_filename_snake,
+        }.get(format_style, format_output_filename_camel)
+
+        pdf_paths = []
         for vendor, paths in vendor_map.items():
             images = [Image.open(p).convert("RGB") for p in paths if p and os.path.isfile(p)]
             if not images:
                 continue
-            outfile = os.path.join(out_dir, f"{vendor}.{self.fmt}")
+
+            out_name = format_func(vendor, len(images), file_meta or {}, self.fmt)
+            outfile = os.path.join(out_dir, out_name)
+
             if self.fmt == "tiff":
                 images[0].save(outfile, save_all=True, append_images=images[1:])
             else:  # pdf
                 images[0].save(outfile, save_all=True, append_images=images[1:], format="PDF")
+                pdf_paths.append(outfile)
+
+        if self.fmt == "pdf" and cfg.get("combined_pdf", False) and pdf_paths:
+            combined_name = format_func("combined", sum(len(v) for v in vendor_map.values()), file_meta or {}, self.fmt)
+            combined_path = os.path.join(out_dir, combined_name)
+            merger = PdfMerger()
+            for p in pdf_paths:
+                merger.append(Path(p))
+            with open(combined_path, "wb") as f:
+                merger.write(f)
+            merger.close()

--- a/processor/__init__.py
+++ b/processor/__init__.py
@@ -1,0 +1,25 @@
+from .file_handler import (
+    get_dynamic_paths,
+    write_excel_log,
+    export_grouped_output,
+    archive_original,
+)
+from .filename_utils import (
+    parse_input_filename_fuzzy,
+    format_output_filename,
+    format_output_filename_camel,
+    format_output_filename_lower,
+    format_output_filename_snake,
+)
+
+__all__ = [
+    "get_dynamic_paths",
+    "write_excel_log",
+    "export_grouped_output",
+    "archive_original",
+    "parse_input_filename_fuzzy",
+    "format_output_filename",
+    "format_output_filename_camel",
+    "format_output_filename_lower",
+    "format_output_filename_snake",
+]

--- a/processor/file_handler.py
+++ b/processor/file_handler.py
@@ -1,0 +1,136 @@
+import io
+import logging
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import pytesseract
+from PyPDF2 import PdfMerger
+from PIL import Image
+
+from .filename_utils import (
+    format_output_filename,
+    format_output_filename_camel,
+    parse_input_filename_fuzzy,
+    format_output_filename_lower,
+    format_output_filename_snake,
+)
+
+
+def get_dynamic_paths(base_file: str, combined_name: str | None = None):
+    """Return output, log and combined directories for ``base_file``."""
+    source_dir = Path(base_file).parent
+    if combined_name:
+        base_stem = Path(combined_name).stem
+    else:
+        base_stem = Path(base_file).stem
+    out_dir = source_dir / "processed" / base_stem / "Vendor"
+    log_dir = source_dir / "logs" / base_stem
+    combined_dir = source_dir / "processed" / base_stem / "Combined"
+    return out_dir, log_dir, combined_dir
+
+
+def write_excel_log(log_entries: List[Dict], base_name: str, log_dir: Path) -> None:
+    """Write ``log_entries`` to an Excel file in ``log_dir``."""
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(log_entries)
+    output_path = Path(log_dir) / f"{base_name}_log.xlsx"
+    df.to_excel(output_path, index=False)
+    logging.info(f"\U0001F4CA Log saved: {output_path}")
+
+
+def export_grouped_output(
+    pages_by_vendor: Dict[str, List[Image.Image]],
+    output_format: str,
+    file_metadata: Dict[str, str] | None,
+    filepath: str | Path,
+    config: Dict,
+) -> List[str]:
+    """Export grouped images by vendor to individual and combined documents."""
+    output_paths: List[str] = []
+
+    if not file_metadata:
+        file_metadata = parse_input_filename_fuzzy(filepath)
+
+    format_style = config.get("file_format", "camel").lower()
+    format_func = {
+        "camel": format_output_filename_camel,
+        "caps": format_output_filename,
+        "lower": format_output_filename_lower,
+        "snake": format_output_filename_snake,
+    }.get(format_style, format_output_filename_camel)
+
+    total_pages = sum(len(imgs) for imgs in pages_by_vendor.values())
+    base_meta = file_metadata.copy()
+    combined_name = (
+        format_func(
+            vendor="",
+            page_count=total_pages,
+            meta=base_meta,
+            output_format=output_format,
+        )
+        .replace("__", "_")
+        .replace("._", ".")
+    )
+
+    out_dir, log_dir, combined_dir = get_dynamic_paths(filepath, combined_name)
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    Path(combined_dir).mkdir(parents=True, exist_ok=True)
+
+    total_vendors = len(pages_by_vendor)
+    for i, (vendor, imgs) in enumerate(pages_by_vendor.items(), start=1):
+        percent = int((i / total_vendors) * 100)
+        logging.info(
+            f"\U0001F4DD Exporting {i}/{total_vendors} ({percent}%) - Vendor: {vendor}"
+        )
+
+        vendor_dir = out_dir / vendor.upper()
+        vendor_dir.mkdir(parents=True, exist_ok=True)
+
+        out_name = format_func(vendor, len(imgs), file_metadata, output_format)
+        out_path = vendor_dir / out_name
+
+        if output_format == "tif":
+            imgs[0].save(out_path, save_all=True, append_images=imgs[1:])
+            output_paths.append(str(out_path))
+
+        elif output_format == "pdf":
+            merger = PdfMerger()
+            for p in imgs:
+                pdf_bytes = pytesseract.image_to_pdf_or_hocr(p, extension="pdf")
+                merger.append(io.BytesIO(pdf_bytes))
+            buffer = io.BytesIO()
+            merger.write(buffer)
+            merger.close()
+            buffer.seek(0)
+            with open(out_path, "wb") as f:
+                f.write(buffer.read())
+            output_paths.append(str(out_path))
+
+        logging.info(f"\U0001F4C4 Saved {vendor} group to: {out_path}")
+
+    if output_format == "pdf":
+        combined_path = combined_dir / combined_name
+        merger = PdfMerger()
+        for pdf_path in output_paths:
+            merger.append(Path(pdf_path))
+        with open(combined_path, "wb") as f:
+            merger.write(f)
+        merger.close()
+        logging.info(f"\U0001F4CE Combined PDF saved: {combined_path}")
+
+    return output_paths
+
+
+def archive_original(original_path: str) -> None:
+    """Move ``original_path`` into an 'Original Scans' archive directory."""
+    original_path_obj = Path(original_path)
+    archive_dir = original_path_obj.parent / "Original Scans"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_dir / original_path_obj.name
+    try:
+        shutil.move(str(original_path_obj), str(archive_path))
+        logging.info(f"Moved original to archive: {archive_path}")
+    except Exception as e:
+        logging.warning(f"Failed to move original: {e}")

--- a/processor/filename_utils.py
+++ b/processor/filename_utils.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Dict
+
+
+def parse_input_filename_fuzzy(filepath: str) -> Dict[str, str]:
+    """Return basic metadata parsed from ``filepath``."""
+    stem = Path(filepath).stem
+    return {"base_name": stem}
+
+
+def _join(parts):
+    return "_".join(p for p in parts if p)
+
+
+def format_output_filename(vendor: str, page_count: int, meta: Dict[str, str], output_format: str) -> str:
+    base = meta.get("base_name", "")
+    return f"{_join([base, vendor.upper(), str(page_count)])}.{output_format}"
+
+
+def format_output_filename_camel(vendor: str, page_count: int, meta: Dict[str, str], output_format: str) -> str:
+    vendor_part = vendor.title().replace(" ", "")
+    base = meta.get("base_name", "")
+    name = _join([base, vendor_part, str(page_count)])
+    return f"{name}.{output_format}"
+
+
+def format_output_filename_lower(vendor: str, page_count: int, meta: Dict[str, str], output_format: str) -> str:
+    vendor_part = vendor.lower().replace(" ", "_")
+    base = meta.get("base_name", "").lower()
+    name = _join([base, vendor_part, str(page_count)])
+    return f"{name}.{output_format}"
+
+
+def format_output_filename_snake(vendor: str, page_count: int, meta: Dict[str, str], output_format: str) -> str:
+    vendor_part = vendor.replace(" ", "_").lower()
+    base = meta.get("base_name", "").replace(" ", "_").lower()
+    name = _join([base, vendor_part, str(page_count)])
+    return f"{name}.{output_format}"


### PR DESCRIPTION
## Summary
- port file_handler and filename_utils from TicketSorter5
- support optional combined PDF creation in `VendorDocumentOutput`
- expose combined PDF toggle in `config.yaml` and GUI
- document the new config option

## Testing
- `python -m compileall -q processor doctr_mod`
- `pip install -q -r doctr_mod/requirements.txt` *(fails: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687823d765cc833183516aef74eed332