### PR TITLE
Fix vendor document output handler

### DIFF
--- a/doctr_mod/output/vendor_doc_output.py
+++ b/doctr_mod/output/vendor_doc_output.py
@@ -1,15 +1,24 @@
-"""Vendor document output handler."""
+"""Vendor document output handler.
 
-from typing import List, Dict, Any
-import os
+This handler groups page images by vendor and writes a multi-page PDF
+or TIFF for each vendor. PDFs can optionally be scaled and combined into
+one file.
+"""
+
+from __future__ import annotations
+
 import logging
+import os
 from pathlib import Path
+from typing import Any, Dict, List
+
 from PIL import Image
 from PyPDF2 import PdfMerger
+
 from .base import OutputHandler
 from processor.filename_utils import (
-    format_output_filename_camel,
     format_output_filename,
+    format_output_filename_camel,
     format_output_filename_lower,
     format_output_filename_snake,
     parse_input_filename_fuzzy,
@@ -17,9 +26,9 @@ from processor.filename_utils import (
 
 
 class VendorDocumentOutput(OutputHandler):
-    """Group page images by vendor and export a multi-page PDF or TIFF."""
+    """Group page images by vendor and export PDFs or TIFFs."""
 
-    def __init__(self, fmt: str = "pdf"):
+    def __init__(self, fmt: str = "pdf") -> None:
         self.fmt = fmt.lower()
 
     def write(self, rows: List[Dict[str, Any]], cfg: dict) -> None:
@@ -31,27 +40,31 @@ class VendorDocumentOutput(OutputHandler):
             vendor = row.get("vendor") or "unknown"
             vendor_map.setdefault(vendor, []).append(row.get("image_path"))
         total = len(vendor_map)
-        for idx, (vendor, paths) in enumerate(vendor_map.items(), 1):
-            logging.info("📝 Exporting %d/%d (%d%%) - Vendor: %s", idx, total, int(idx / total * 100), vendor)
-
 
         file_meta = None
         if rows:
             file_meta = parse_input_filename_fuzzy(rows[0].get("file", ""))
 
-        format_style = cfg.get("file_format", "camel").lower()
+        fmt_style = cfg.get("file_format", "camel").lower()
         format_func = {
             "camel": format_output_filename_camel,
             "caps": format_output_filename,
             "lower": format_output_filename_lower,
             "snake": format_output_filename_snake,
-        }.get(format_style, format_output_filename_camel)
+        }.get(fmt_style, format_output_filename_camel)
 
-        pdf_paths = []
+        pdf_paths: List[str] = []
         pdf_scale = float(cfg.get("pdf_scale", 1.0))
         pdf_res = int(cfg.get("pdf_resolution", 150))
 
-        for vendor, paths in vendor_map.items():
+        for idx, (vendor, paths) in enumerate(vendor_map.items(), 1):
+            logging.info(
+                "📝 Exporting %d/%d (%d%%) - Vendor: %s",
+                idx,
+                total,
+                int(idx / total * 100),
+                vendor,
+            )
             images = [Image.open(p).convert("RGB") for p in paths if p and os.path.isfile(p)]
             if not images:
                 continue
@@ -59,33 +72,38 @@ class VendorDocumentOutput(OutputHandler):
             out_name = format_func(vendor, len(images), file_meta or {}, self.fmt)
             outfile = os.path.join(out_dir, out_name)
 
+            scaled = images
             if pdf_scale != 1.0 and self.fmt == "pdf":
-                scaled = [img.resize((int(img.width * pdf_scale), int(img.height * pdf_scale)), Image.LANCZOS) for img in images]
-            else:
-                scaled = images
-            outfile = os.path.join(out_dir, f"{vendor}.{self.fmt}")
+                scaled = [
+                    img.resize(
+                        (int(img.width * pdf_scale), int(img.height * pdf_scale)),
+                        Image.LANCZOS,
+                    )
+                    for img in images
+                ]
 
             if self.fmt == "tiff":
                 scaled[0].save(outfile, save_all=True, append_images=scaled[1:])
             else:  # pdf
-                images[0].save(outfile, save_all=True, append_images=images[1:], format="PDF")
-            logging.info("📄 Saved %s group to: %s", vendor, outfile)
-                images[0].save(outfile, save_all=True, append_images=images[1:], format="PDF")
-                pdf_paths.append(outfile)
-
-        if self.fmt == "pdf" and cfg.get("combined_pdf", False) and pdf_paths:
-            combined_name = format_func("combined", sum(len(v) for v in vendor_map.values()), file_meta or {}, self.fmt)
-            combined_path = os.path.join(out_dir, combined_name)
-            merger = PdfMerger()
-            for p in pdf_paths:
-                merger.append(Path(p))
-            with open(combined_path, "wb") as f:
-                merger.write(f)
-            merger.close()
                 scaled[0].save(
                     outfile,
                     save_all=True,
                     append_images=scaled[1:],
                     format="PDF",
                     resolution=pdf_res,
+                )
+                pdf_paths.append(outfile)
+            logging.info("📄 Saved %s group to: %s", vendor, outfile)
 
+        if self.fmt == "pdf" and cfg.get("combined_pdf", False) and pdf_paths:
+            combined_name = format_func(
+                "combined", sum(len(v) for v in vendor_map.values()), file_meta or {}, self.fmt
+            )
+            combined_path = os.path.join(out_dir, combined_name)
+            merger = PdfMerger()
+            for path in pdf_paths:
+                merger.append(Path(path))
+            with open(combined_path, "wb") as f:
+                merger.write(f)
+            merger.close()
+            logging.info("📚 Combined PDF saved to: %s", combined_path)


### PR DESCRIPTION
## Summary
- repair `vendor_doc_output.py` which had incorrect indentation and truncated logic

## Testing
- `python3 -m py_compile doctr_mod/output/vendor_doc_output.py`

------
https://chatgpt.com/codex/tasks/task_e_687921cd3f6c83318eff5f3cf604a77a