### PR TITLE
Add logs under output_dir

### DIFF
--- a/doctr_mod/config.yaml
+++ b/doctr_mod/config.yaml
@@ -7,6 +7,14 @@ output_dir: ./outputs
 combined_pdf: false
 csv_filename: results.csv
 output_format: [csv, excel, vendor_pdf]
+output_csv: true
+ticket_numbers_csv: true
+page_fields_csv: true
+ticket_number_exceptions_csv: true
+manifest_number_exceptions_csv: true
+summary_report: true
+log_csv: true
+log_html: true
 sharepoint_config:
   site_url: "https://company.sharepoint.com/sites/TruckTickets"
   library: "Documents"

--- a/doctr_mod/docs/USER_GUIDE.md
+++ b/doctr_mod/docs/USER_GUIDE.md
@@ -72,9 +72,12 @@ manifest_number: {...}
 input_pdf: ./data/sample.pdf
 input_dir: ./data/
 batch_mode: true
-output_csv: ./output/ocr/all_results.csv
-ticket_numbers_csv: ./output/ocr/combined_ticket_numbers.csv
-page_fields_csv: ./output/ocr/page_fields.csv
+output_csv: true
+ticket_numbers_csv: true
+page_fields_csv: true
+ticket_number_exceptions_csv: true
+manifest_number_exceptions_csv: true
+summary_report: true
 output_images_dir: ./output/images/
 draw_roi: true
 orientation_check: tesseract  # tesseract, doctr, or none
@@ -86,6 +89,9 @@ parallel: true
 num_workers: 4
 debug: false
 profile: false
+
+Each `*_csv` option above controls whether that report is generated. When set to
+`true`, the file is written under `<output_dir>/logs/`.
 
 When `profile` is set to `true`, the program displays progress bars and
 records timing information for each file in `performance_log.csv`.
@@ -100,13 +106,14 @@ sets the DPI of the saved PDF.
 
 ### Output Files
 
-- `combined_results.csv` – raw OCR results for every page
-- `combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag and
-  **ROI Image Link** and **Manifest ROI Link** columns when the respective values are not `valid`
-- `page_fields.csv` – per-page summary of all extracted fields with validation status
-- `ticket_number_exceptions.csv` – pages with no ticket number
-- `duplicate_ticket_exceptions.csv` – pages where the same vendor and ticket number combination appears more than once ("duplicate ticket pages") and any pages that produced no OCR text
-- `manifest_number_exceptions.csv` – pages where the manifest number is missing or invalid
+- The application writes reports under `<output_dir>/logs/` when enabled:
+  - `ocr/combined_results.csv` – raw OCR results for every page
+  - `ocr/combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag and
+    **ROI Image Link** and **Manifest ROI Link** columns when the respective values are not `valid`
+  - `ocr/page_fields.csv` – per-page summary of all extracted fields with validation status
+  - `ticket_number/ticket_number_exceptions.csv` – pages with no ticket number
+  - `manifest_number/manifest_number_exceptions.csv` – pages where the manifest number is missing or invalid
+  - `summary/summary.csv` – aggregated counts of valid, review, and invalid pages
 
 ## Automated Scanning Workflow
 

--- a/doctr_mod/docs/sample_config.yaml
+++ b/doctr_mod/docs/sample_config.yaml
@@ -1,10 +1,12 @@
 input_pdf: ./data/sample.pdf
 input_dir: ./data/
 batch_mode: true
-output_csv: ./output/ocr/all_results.csv
-ticket_numbers_csv: ./output/ocr/combined_ticket_numbers.csv
-page_fields_csv: ./output/ocr/page_fields.csv
-manifest_number_exceptions_csv: ./output/logs/manifest_number/manifest_number_exceptions.csv
+output_csv: true
+ticket_numbers_csv: true
+page_fields_csv: true
+ticket_number_exceptions_csv: true
+manifest_number_exceptions_csv: true
+summary_report: true
 output_images_dir: ./output/images/
 draw_roi: true
 orientation_check: tesseract  # tesseract, doctr, or none

--- a/doctr_mod/doctr_ocr_to_csv.py
+++ b/doctr_mod/doctr_ocr_to_csv.py
@@ -171,6 +171,7 @@ def run_pipeline():
         handler.write(all_rows, cfg)
 
     reporting_utils.create_reports(all_rows, cfg)
+    reporting_utils.export_log_reports(cfg)
 
     if cfg.get("profile"):
         _write_performance_log(perf_records, cfg)


### PR DESCRIPTION
## Summary
- generate log and report files relative to `output_dir`
- provide helper `_report_path` and `export_log_reports`
- toggle reports using boolean flags in `config.yaml`
- document new configuration in sample config and user guide

## Testing
- `python -m py_compile doctr_mod/doctr_ocr/reporting_utils.py doctr_mod/doctr_ocr_to_csv.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687a78c898f48331bbfc0aa69259b67e