### PR TITLE
Handle empty extraction methods

### DIFF
--- a/doctr_mod/doctr_ocr/vendor_utils.py
+++ b/doctr_mod/doctr_ocr/vendor_utils.py
@@ -136,8 +136,11 @@ def extract_vendor_fields(result_page, vendor_name: str, extraction_rules, pil_i
     result = {}
     for field in ["ticket_number", "manifest_number", "material_type", "truck_number", "date"]:
         field_rules = vendor_rule.get(field)
-        if field_rules:
-            result[field] = extract_field(result_page, field_rules, pil_img, cfg)
-        else:
+        if not field_rules:
             result[field] = None
+            continue
+        if field_rules.get("method") is None:
+            result[field] = None
+            continue
+        result[field] = extract_field(result_page, field_rules, pil_img, cfg)
     return result

--- a/doctr_mod/extraction_rules.yaml
+++ b/doctr_mod/extraction_rules.yaml
@@ -61,14 +61,6 @@ WL_Reid:
     roi: [ 0.601, 0.106, 0.992, 0.203 ]
     regex: "\\d{3,}$" # must be at least 3 digits
     validation_regex: "^\\d{3,}$"  # must be at least 3 digits
-  manifest_number:
-    method: null
-    label: null
-    regex: null
-  material_type:
-    method: null
-    label: null
-    regex: null
   truck_number:
     method: roi
     roi: [ 0.455, 0.261, 0.770, 0.317 ]


### PR DESCRIPTION
## Summary
- avoid attempting extraction when a field's method is `null`
- remove unused `manifest_number` and `material_type` blocks for `WL_Reid`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a9ca1a2808331804152a4d065f964