### PR TITLE
Use field constant across OCR pipeline

### DIFF
--- a/doctr_mod/doctr_ocr/vendor_utils.py
+++ b/doctr_mod/doctr_ocr/vendor_utils.py
@@ -134,7 +134,7 @@ def extract_vendor_fields(result_page, vendor_name: str, extraction_rules, pil_i
     """Extract all configured fields for ``vendor_name`` from ``result_page``."""
     vendor_rule = extraction_rules.get(vendor_name, extraction_rules.get("DEFAULT"))
     result = {}
-    for field in ["ticket_number", "manifest_number", "material_type", "truck_number", "date"]:
+    for field in FIELDS:
         field_rules = vendor_rule.get(field)
         if field_rules:
             result[field] = extract_field(result_page, field_rules, pil_img, cfg)

--- a/doctr_mod/doctr_ocr_to_csv.py
+++ b/doctr_mod/doctr_ocr_to_csv.py
@@ -19,6 +19,7 @@ from doctr_ocr.vendor_utils import (
     load_vendor_rules_from_csv,
     find_vendor,
     extract_vendor_fields,
+    FIELDS,
 )
 from doctr_ocr.ocr_utils import (
     extract_images_generator,
@@ -81,10 +82,7 @@ def process_file(
         if result_page is not None:
             fields = extract_vendor_fields(result_page, vendor_name, extraction_rules)
         else:
-            fields = {
-                f: None
-                for f in ["ticket_number", "manifest_number", "material_type", "truck_number", "date"]
-            }
+            fields = {f: None for f in FIELDS}
         row = {
             "file": pdf_path,
             "page": i + 1,


### PR DESCRIPTION
## Summary
- reuse `FIELDS` constant in `vendor_utils.extract_vendor_fields`
- import `FIELDS` in `doctr_ocr_to_csv.py` and use it for default field dict

## Testing
- `python -m py_compile doctr_mod/doctr_ocr/vendor_utils.py doctr_mod/doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_687a9c51b458833191342d1e72fdf477