### PR TITLE
Add display_name column support

### DIFF
--- a/doctr_mod/docs/DEVELOPER_GUIDE.md
+++ b/doctr_mod/docs/DEVELOPER_GUIDE.md
@@ -28,8 +28,8 @@
   - `ocr_utils.py` – OCR helpers
   - `preflight.py` – optional preflight checks
   - `reporting_utils.py` – CSV/HTML log exports
-  - `vendor_utils.py` – vendor rules and field extraction
-- **ocr_keywords.csv** – vendor keywords
+- `vendor_utils.py` – vendor rules and field extraction
+- **ocr_keywords.csv** – vendor keywords (with optional `display_name` column)
 - **extraction_rules.yaml** – field extraction definitions
 - **config.yaml** – main application configuration
 
@@ -48,6 +48,7 @@
 
 - `find_vendor(page_text, vendor_rules)`
     - Scans OCR text for vendor keywords/exclusions (case-insensitive)
+    - Returns `(vendor_name, vendor_type, matched_term, display_name)`
 - `extract_vendor_fields(result_page, vendor_name, extraction_rules, pil_img, cfg)`
     - Extracts all needed fields for a page/vendor
 - `extract_field(result_page, field_rules, pil_img, cfg)`

--- a/doctr_mod/docs/USER_GUIDE.md
+++ b/doctr_mod/docs/USER_GUIDE.md
@@ -37,13 +37,14 @@ CSV reports.
 
 ### `ocr_keywords.csv`
 
-| vendor_name | vendor_type | vendor_match     | vendor_excludes |
-|-------------|-------------|------------------|-----------------|
-| Waste Mgmt  | landfill    | wm, waste        |                 |
-| NTX         | landfill    | ntx, north texas |                 |
+| vendor_name | display_name | vendor_type | vendor_match     | vendor_excludes |
+|-------------|--------------|-------------|------------------|-----------------|
+| Waste Mgmt  | Waste Mgmt   | landfill    | wm, waste        |                 |
+| NTX         | NTX         | landfill    | ntx, north texas |                 |
 
 - **vendor_match**: Comma-separated keywords (case-insensitive)
 - **vendor_excludes**: Comma-separated terms to avoid false matches
+- **display_name**: Optional vendor name used for output files; defaults to `vendor_name`
 
 ---
 

--- a/doctr_mod/doctr_ocr/vendor_utils.py
+++ b/doctr_mod/doctr_ocr/vendor_utils.py
@@ -22,6 +22,7 @@ def load_vendor_rules_from_csv(path: str):
     vendor_rules = []
     for _, row in df.iterrows():
         name = str(row["vendor_name"]).strip()
+        display = str(row.get("display_name", "")).strip() or name
         vtype = str(row.get("vendor_type", "")).strip()
         matches_str = row.get("vendor_match", "")
         if pd.isna(matches_str):
@@ -36,6 +37,7 @@ def load_vendor_rules_from_csv(path: str):
         vendor_rules.append(
             {
                 "vendor_name": name,
+                "display_name": display,
                 "vendor_type": vtype,
                 "match_terms": matches,
                 "exclude_terms": excludes,
@@ -51,8 +53,13 @@ def find_vendor(page_text: str, vendor_rules):
         matched_terms = [term for term in rule["match_terms"] if term in page_text_lower]
         found_exclude = any(exclude in page_text_lower for exclude in rule["exclude_terms"])
         if matched_terms and not found_exclude:
-            return rule["vendor_name"], rule["vendor_type"], matched_terms[0]
-    return "", "", ""
+            return (
+                rule["vendor_name"],
+                rule["vendor_type"],
+                matched_terms[0],
+                rule.get("display_name", rule["vendor_name"]),
+            )
+    return "", "", "", ""
 
 
 def extract_field(result_page, field_rules: Dict[str, Any], pil_img=None, cfg=None):

--- a/doctr_mod/doctr_ocr_to_csv.py
+++ b/doctr_mod/doctr_ocr_to_csv.py
@@ -78,7 +78,7 @@ def process_file(
         ocr_time = time.perf_counter() - page_start
         logging.info("⏱️ Page %d OCR time: %.2fs", i + 1, ocr_time)
 
-        vendor_name, vendor_type, _ = find_vendor(text, vendor_rules)
+        vendor_name, vendor_type, _, display_name = find_vendor(text, vendor_rules)
         if result_page is not None:
             fields = extract_vendor_fields(result_page, vendor_name, extraction_rules)
         else:
@@ -86,14 +86,14 @@ def process_file(
         row = {
             "file": pdf_path,
             "page": i + 1,
-            "vendor": vendor_name,
+            "vendor": display_name,
             **fields,
             "image_path": save_page_image(
                 img,
                 pdf_path,
                 i,
                 cfg,
-                vendor=vendor_name,
+                vendor=display_name,
                 ticket_number=fields.get("ticket_number"),
             ),
             "ocr_text": text,

--- a/doctr_mod/ocr_keywords.csv
+++ b/doctr_mod/ocr_keywords.csv
@@ -1,14 +1,14 @@
-vendor_name,vendor_type,vendor_match,vendor_excludes
-CorpoTechs,Trucking,"3317 finley, 469-845-3334, corpotechs, suite 226",
-JDandSon,Trucking,"jd and son trucking enterprises llc, jd and son, jdandsontrucking, dandsontrucking, dandsontrucking@gmail.com, p.o. box 703517",
-Lindamood,Trucking,"2020 nursery, lindamood, nursery","CorpoTechs, JD&Son, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid, Big City, Austin Asphalt, Heidelberg, 3317 finley, 469-845-3334, corpotechs, suite 226, jd and son trucking enterprises llc, jd and son, jdandsontrucking, dandsontrucking, dandsontrucking@gmail.com, p.o. box 703517, 10550 goodnight lane, portillo, portillo & sons, 1930 hinton, reeder, reeder concrete, 469.291.7755, 5326 w. ledbetter, roadstar, roadstar management, roadstar trucking, roadstarmgmt@yahoo.com, 534-6557, 707-8768, 726-2458, box 936, roberts, seagoville, OFFICE (469) 726-2458, DISPATCH (214) 707-8768, EMERGENCY (214) 534-6557, 469-660-6912, cell 214-973-0640, off 972-780-5263, tarangooffice@yahoo.com, 5840 spring valley, 625-5160, w.l. reid, reid, Big City Crushed Concrete, Box 29816, big city, Austin Asphalt, Austin Asphalt L.P, 11143 goodnight lane, Heidelberg, Arcosa"
-Portillo,Trucking,"10550 goodnight lane, portillo, portillo & sons",
-RCI,Trucking,"1930 hinton, reeder, reeder concrete",
-Roadstar,Trucking,"469.291.7755, 5326 w. ledbetter, roadstar, roadstar management, roadstar trucking, roadstarmgmt@yahoo.com",
-Roberts,Trucking,"534-6557, 707-8768, 726-2458, box 936, roberts, seagoville, OFFICE (469) 726-2458, DISPATCH (214) 707-8768, EMERGENCY (214) 534-6557",
-Tarango,Trucking,"469-660-6912, cell 214-973-0640, off 972-780-5263, tarangooffice@yahoo.com",
-WL_Reid,Trucking,"5840 spring valley, 625-5160, w.l. reid, reid",
-Big City,Materials,"Big City Crushed Concrete, Box 29816, big city","CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
-Austin Asphalt,Materials,"Austin Asphalt, Austin Asphalt L.P, 11143 goodnight lane","CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
-Heidelberg,Materials,Heidelberg,"CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
-Arcosa,Materials,Arcosa,"CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
+vendor_name,display_name,vendor_type,vendor_match,vendor_excludes
+CorpoTechs,CorpoTechs,Trucking,"3317 finley, 469-845-3334, corpotechs, suite 226",
+JDandSon,JDandSon,Trucking,"jd and son trucking enterprises llc, jd and son, jdandsontrucking, dandsontrucking, dandsontrucking@gmail.com, p.o. box 703517",
+Lindamood,Lindamood,Trucking,"2020 nursery, lindamood, nursery","CorpoTechs, JD&Son, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid, Big City, Austin Asphalt, Heidelberg, 3317 finley, 469-845-3334, corpotechs, suite 226, jd and son trucking enterprises llc, jd and son, jdandsontrucking, dandsontrucking, dandsontrucking@gmail.com, p.o. box 703517, 10550 goodnight lane, portillo, portillo & sons, 1930 hinton, reeder, reeder concrete, 469.291.7755, 5326 w. ledbetter, roadstar, roadstar management, roadstar trucking, roadstarmgmt@yahoo.com, 534-6557, 707-8768, 726-2458, box 936, roberts, seagoville, OFFICE (469) 726-2458, DISPATCH (214) 707-8768, EMERGENCY (214) 534-6557, 469-660-6912, cell 214-973-0640, off 972-780-5263, tarangooffice@yahoo.com, 5840 spring valley, 625-5160, w.l. reid, reid, Big City Crushed Concrete, Box 29816, big city, Austin Asphalt, Austin Asphalt L.P, 11143 goodnight lane, Heidelberg, Arcosa"
+Portillo,Portillo,Trucking,"10550 goodnight lane, portillo, portillo & sons",
+RCI,RCI,Trucking,"1930 hinton, reeder, reeder concrete",
+Roadstar,Roadstar,Trucking,"469.291.7755, 5326 w. ledbetter, roadstar, roadstar management, roadstar trucking, roadstarmgmt@yahoo.com",
+Roberts,Roberts,Trucking,"534-6557, 707-8768, 726-2458, box 936, roberts, seagoville, OFFICE (469) 726-2458, DISPATCH (214) 707-8768, EMERGENCY (214) 534-6557",
+Tarango,Tarango,Trucking,"469-660-6912, cell 214-973-0640, off 972-780-5263, tarangooffice@yahoo.com",
+WL_Reid,WL_Reid,Trucking,"5840 spring valley, 625-5160, w.l. reid, reid",
+Big City,Big City,Materials,"Big City Crushed Concrete, Box 29816, big city","CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
+Austin Asphalt,Austin Asphalt,Materials,"Austin Asphalt, Austin Asphalt L.P, 11143 goodnight lane","CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
+Heidelberg,Heidelberg,Materials,Heidelberg,"CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"
+Arcosa,Arcosa,Materials,Arcosa,"CorpoTechs, JD&Son, Lindamood, Portillo, RCI, Roadstar, Roberts, Tarango, WL Reid"


### PR DESCRIPTION
## Summary
- add optional `display_name` column to vendor keywords
- use `display_name` when naming vendor outputs
- document the new column in the guides

## Testing
- `python -m py_compile doctr_mod/doctr_ocr/vendor_utils.py doctr_mod/doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_687a94afbd4c8331971a18cdcc71f9c6