### PR TITLE
Fix JDandSon ticket parsing

### DIFF
--- a/doctr_mod/doctr_ocr/vendor_utils.py
+++ b/doctr_mod/doctr_ocr/vendor_utils.py
@@ -99,7 +99,7 @@ def extract_field(result_page, field_rules: Dict[str, Any], pil_img=None, cfg=No
                 if DEBUG:
                     print(f"[DEBUG] Matching '{regex}' in '{text}' => {m.group(0) if m else None}")
                 if m:
-                    return m.group(0)
+                    return m.group(1) if m.lastindex else m.group(0)
         return candidates[0] if candidates else None
 
     elif method == "below_label":

--- a/doctr_mod/extraction_rules.yaml
+++ b/doctr_mod/extraction_rules.yaml
@@ -3,10 +3,10 @@ JDandSon:
     method: roi
     roi: [ 0.658, 0.163, 0.999, 0.281 ]
     label: "PIT/DUMP TICKET"
-    regex: '(?<!№)\b(?:A\s?\d{5,6}|NO\s?\d{5,6}|\d{5,6})\b'     # match 5 or 6 digits, optionally preceded by "A" or "NO"
-    validation_regex: '^(A\d{5,6}|\d{5,6})$'      # must start with "A" or be 5 or 6 digits, not preceded by "№"
+    regex: '(?i)(?<!№)\b(?:A\s*|NO\.?\s*)?(\d{5,6})\b'  # capture 5-6 digits, ignoring optional "A" or "NO" prefix
+    validation_regex: '^\d{5,6}$'      # must be exactly 5 or 6 digits
     fallback_method: below_label
-    fallback_regex: '(?<!№)\b(?:A\s?\d{5,6}|NO\s?\d{5,6}|\d{5,6})\b'       # match 5 or 6 digits, optionally preceded by "A" or "NO"
+    fallback_regex: '(?i)(?<!№)\b(?:A\s*|NO\.?\s*)?(\d{5,6})\b'
 
   manifest_number:
     method: roi


### PR DESCRIPTION
## Summary
- clean ticket number by using capture groups
- ignore `A`/`NO` prefixes for JDandSon ticket numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab0ad6a188331aa0e543af8748d37