### PR TITLE
Add preflight blank page detection

### DIFF
--- a/doctr_mod/README.md
+++ b/doctr_mod/README.md
@@ -50,6 +50,8 @@ See `config.yaml` for all available options. Key settings include:
 - `validation_output_csv` – mismatches written when `run_type` is `validation`
 - `sharepoint_config` – credentials and target folder if using SharePoint
 - `profile` – when true, write `performance_log.csv` and show progress bars
+- `preflight.min_resolution` – skip OCR if page dimensions fall below this size
+- `preflight.blank_std_threshold` – grayscale standard deviation below this is considered blank
 
 ## Extending Outputs
 Additional output formats can be added by implementing the `OutputHandler` interface in `output/base.py` and registering it in `output/factory.py`.

--- a/doctr_mod/config.yaml
+++ b/doctr_mod/config.yaml
@@ -65,3 +65,10 @@ run_type: initial  # initial or validation
 hash_db_csv: ./outputs/hash_db.csv
 validation_output_csv: ./outputs/validation_mismatches.csv
 
+preflight:
+  enabled: false
+  dpi_threshold: 150
+  min_chars: 5
+  min_resolution: 600
+  blank_std_threshold: 3.0
+

--- a/doctr_mod/docs/USER_GUIDE.md
+++ b/doctr_mod/docs/USER_GUIDE.md
@@ -93,6 +93,12 @@ profile: false
 run_type: initial  # initial or validation
 hash_db_csv: ./outputs/hash_db.csv
 validation_output_csv: ./outputs/validation_mismatches.csv
+preflight:
+  enabled: false
+  dpi_threshold: 150
+  min_chars: 5
+  min_resolution: 600
+  blank_std_threshold: 3.0
 
 Each `*_csv` option above controls whether that report is generated. When set to
 `true`, the file is written under `<output_dir>/logs/`.


### PR DESCRIPTION
## Summary
- check page resolution and blankness before OCR
- add `preflight` section with defaults in `config.yaml`
- document new config options in README and User Guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687ab52e34f0833181c43743f16f1973