### PR TITLE
Add preflight support

### DIFF
--- a/doctr_mod/config.yaml
+++ b/doctr_mod/config.yaml
@@ -65,3 +65,10 @@ run_type: initial  # initial or validation
 hash_db_csv: ./outputs/hash_db.csv
 validation_output_csv: ./outputs/validation_mismatches.csv
 
+preflight:
+  enabled: false
+  dpi_threshold: 150
+  min_chars: 5
+
+preflight_exceptions_csv: ./output/logs/preflight/preflight_exceptions.csv
+

--- a/doctr_mod/docs/sample_config.yaml
+++ b/doctr_mod/docs/sample_config.yaml
@@ -18,3 +18,7 @@ parallel: true
 num_workers: 4
 debug: false
 profile: false
+
+preflight:
+  enabled: false
+

--- a/doctr_mod/doctr_ocr/reporting_utils.py
+++ b/doctr_mod/doctr_ocr/reporting_utils.py
@@ -180,3 +180,17 @@ def create_reports(rows: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
         pd.DataFrame([summary]).to_csv(summary_path, index=False)
 
 
+def export_preflight_exceptions(exceptions: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
+    """Write preflight exception rows to CSV if enabled."""
+    if not exceptions:
+        return
+    out_path = _report_path(
+        cfg,
+        "preflight_exceptions_csv",
+        "preflight/preflight_exceptions.csv",
+    )
+    if out_path:
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        pd.DataFrame(exceptions).to_csv(out_path, index=False)
+
+

--- a/doctr_mod/doctr_ocr_to_csv.py
+++ b/doctr_mod/doctr_ocr_to_csv.py
@@ -26,6 +26,7 @@ from doctr_ocr.ocr_utils import (
     correct_image_orientation,
     get_image_hash,
 )
+from doctr_ocr.preflight import run_preflight
 from tqdm import tqdm
 from output.factory import create_handlers
 from doctr_ocr import reporting_utils
@@ -45,8 +46,8 @@ logging.basicConfig(
 
 def process_file(
     pdf_path: str, cfg: dict, vendor_rules, extraction_rules
-) -> Tuple[List[Dict], Dict]:
-    """Process ``pdf_path`` and return rows and performance stats."""
+) -> Tuple[List[Dict], Dict, List[Dict]]:
+    """Process ``pdf_path`` and return rows, performance stats and preflight exceptions."""
 
     logging.info("🚀 Processing: %s", pdf_path)
 
@@ -54,6 +55,8 @@ def process_file(
     rows: List[Dict] = []
     orient_method = cfg.get("orientation_check", "tesseract")
     total_pages = count_total_pages([pdf_path], cfg)
+
+    skip_pages, preflight_excs = run_preflight(pdf_path, cfg)
 
     # Extract all pages first so we can time the extraction step
     ext = os.path.splitext(pdf_path)[1].lower()
@@ -71,12 +74,16 @@ def process_file(
     for i, img in enumerate(
         tqdm(images, total=len(images), desc=os.path.basename(pdf_path), unit="page")
     ):
-        img = correct_image_orientation(img, i + 1, method=orient_method)
+        page_num = i + 1
+        if page_num in skip_pages:
+            logging.info("🚫 Skipping page %d due to preflight", page_num)
+            continue
+        img = correct_image_orientation(img, page_num, method=orient_method)
         page_hash = get_image_hash(img)
         page_start = time.perf_counter()
         text, result_page = engine(img)
         ocr_time = time.perf_counter() - page_start
-        logging.info("⏱️ Page %d OCR time: %.2fs", i + 1, ocr_time)
+        logging.info("⏱️ Page %d OCR time: %.2fs", page_num, ocr_time)
 
         vendor_name, vendor_type, _, display_name = find_vendor(text, vendor_rules)
         if result_page is not None:
@@ -85,7 +92,7 @@ def process_file(
             fields = {f: None for f in FIELDS}
         row = {
             "file": pdf_path,
-            "page": i + 1,
+            "page": page_num,
             "vendor": display_name,
             **fields,
             "image_path": save_page_image(
@@ -106,10 +113,10 @@ def process_file(
     duration = time.perf_counter() - start
     perf = {
         "file": os.path.basename(pdf_path),
-        "pages": len(images),
+        "pages": len(rows),
         "duration_sec": round(duration, 2),
     }
-    return rows, perf
+    return rows, perf, preflight_excs
 
 
 def save_page_image(
@@ -225,13 +232,15 @@ def run_pipeline():
 
     all_rows: List[Dict] = []
     perf_records: List[Dict] = []
+    preflight_exceptions: List[Dict] = []
     for idx, f in enumerate(files, 1):
         logging.info("📄 %d/%d Processing: %s", idx, len(files), os.path.basename(f))
         file_start = time.perf_counter()
-        rows, perf = process_file(f, cfg, vendor_rules, extraction_rules)
+        rows, perf, pf_exc = process_file(f, cfg, vendor_rules, extraction_rules)
         file_time = time.perf_counter() - file_start
         perf_records.append(perf)
         all_rows.extend(rows)
+        preflight_exceptions.extend(pf_exc)
 
         vendor_counts = {}
         for r in rows:
@@ -250,6 +259,7 @@ def run_pipeline():
         handler.write(all_rows, cfg)
 
     reporting_utils.create_reports(all_rows, cfg)
+    reporting_utils.export_preflight_exceptions(preflight_exceptions, cfg)
     reporting_utils.export_log_reports(cfg)
 
     if cfg.get("run_type", "initial") == "validation":

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import importlib.util
+import sys
+import pytest
+from PIL import Image
+import types
+
+SPEC = importlib.util.spec_from_file_location(
+    "doctr_ocr_to_csv",
+    Path(__file__).resolve().parents[1] / "doctr_mod" / "doctr_ocr_to_csv.py",
+)
+doctr_ocr_to_csv = importlib.util.module_from_spec(SPEC)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "doctr_mod"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("office365", types.ModuleType("office365"))
+client_mod = types.ModuleType("client_context")
+client_mod.ClientContext = type("ClientContext", (), {})
+sys.modules.setdefault("office365.sharepoint.client_context", client_mod)
+auth_mod = types.ModuleType("user_credential")
+auth_mod.UserCredential = type("UserCredential", (), {})
+sys.modules.setdefault("office365.runtime.auth.user_credential", auth_mod)
+SPEC.loader.exec_module(doctr_ocr_to_csv)
+
+
+def test_process_file_skips_pages(monkeypatch, tmp_path):
+    # create dummy images
+    img1 = Image.new("RGB", (10, 10), color="white")
+    img2 = Image.new("RGB", (10, 10), color="white")
+
+    monkeypatch.setattr(
+        doctr_ocr_to_csv,
+        "extract_images_generator",
+        lambda path, poppler_path=None: [img1, img2],
+    )
+
+    def fake_run_preflight(path, cfg):
+        return {1}, [{"file": path, "page": 1, "error": "bad", "extract": "out.pdf"}]
+
+    monkeypatch.setattr(doctr_ocr_to_csv, "run_preflight", fake_run_preflight)
+    monkeypatch.setattr(doctr_ocr_to_csv, "count_total_pages", lambda pdfs, cfg: 2)
+
+    calls = []
+
+    def fake_engine(name):
+        def run(img):
+            calls.append(img)
+            return "TEXT", None
+
+        return run
+
+    monkeypatch.setattr(doctr_ocr_to_csv, "get_engine", fake_engine)
+    monkeypatch.setattr(doctr_ocr_to_csv, "correct_image_orientation", lambda img, page_num, method=None: img)
+    monkeypatch.setattr(doctr_ocr_to_csv, "save_page_image", lambda img, pdf, idx, cfg, vendor=None, ticket_number=None: str(tmp_path / f"{idx}.png"))
+
+    rows, perf, exc = doctr_ocr_to_csv.process_file(
+        "sample.pdf",
+        {"preflight": {"enabled": True}, "output_dir": str(tmp_path)},
+        [],
+        {},
+    )
+
+    assert len(calls) == 1  # second page only
+    assert len(rows) == 1
+    assert rows[0]["page"] == 2
+    assert exc[0]["page"] == 1


### PR DESCRIPTION
## Summary
- run preflight checks before extracting images
- track skipped pages and export them
- allow enabling with `preflight.enabled` config option
- test skipping behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab530046c8331aca6a2000352f614