### PR TITLE
Add ROI check for ticket numbers

### DIFF
--- a/doctr_mod/docs/USER_GUIDE.md
+++ b/doctr_mod/docs/USER_GUIDE.md
@@ -104,6 +104,7 @@ records timing information for each file in `performance_log.csv`.
 - `tesseract` (default): use Tesseract's OSD to correct orientation
 - `doctr`: use Doctr's angle prediction model
 - `none`: skip orientation checks
+- After orientation correction a quick OCR check runs on the ticket number ROI (top-right by default or vendor-specific). Pages where this region contains no digits are logged to `roi_exceptions.csv` with reason `ticket-number missing/obscured`.
 
 `pdf_scale` allows shrinking vendor PDF pages before saving. `pdf_resolution`
 sets the DPI of the saved PDF.


### PR DESCRIPTION
## Summary
- add `roi_has_digits` utility to quickly OCR numeric text from ROI
- flag pages with missing ROI numbers in `roi_exceptions.csv`
- document ROI check in USER_GUIDE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab52ee8e483318f47748e7182604a