### PR TITLE
Add vendor breakdown to summary report

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ The source code now lives under `src/doctr_process` and provides OCR extraction,
 2. Configure options in `src/doctr_process/doctr_mod/config.yaml` or `configf.yaml` at the repository root.
 3. Run the main pipeline:
 
-```bash
-python src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
-```
+ ```bash
+ python src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
+ ```
 
 Sample ticket images can be found under `docs/samples` for testing the OCR models.
+
+The generated `summary.csv` now includes per-file vendor counts appended below
+the overall totals. Each row lists the PDF filename, vendor name and the number
+of pages matched for that vendor.

--- a/src/doctr_process/doctr_mod/doctr_ocr/reporting_utils.py
+++ b/src/doctr_process/doctr_mod/doctr_ocr/reporting_utils.py
@@ -177,7 +177,17 @@ def create_reports(rows: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
             "manifest_review": int((df["manifest_valid"] == "review").sum()),
             "manifest_invalid": int((df["manifest_valid"] == "invalid").sum()),
         }
-        pd.DataFrame([summary]).to_csv(summary_path, index=False)
+        summary_df = pd.DataFrame([summary])
+
+        vendor_counts = (
+            df.groupby(["file", "vendor"]).size().reset_index(name="page_count")
+        )
+
+        with open(summary_path, "w", newline="", encoding="utf-8") as f:
+            summary_df.to_csv(f, index=False)
+            if not vendor_counts.empty:
+                f.write("\n")
+                vendor_counts.to_csv(f, index=False)
 
 
 def export_preflight_exceptions(exceptions: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- extend summary.csv generation with per-file vendor counts
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688398437c6883318e3783ee75ce7b43