### PR TITLE
Add condensed ticket numbers report

### DIFF
--- a/configf.yaml
+++ b/configf.yaml
@@ -8,6 +8,7 @@ reports:
   csv_logs:
     combined_results: true
     ticket_numbers: true
+    ticket_numbers_condensed: true
     page_fields: true
     ticket_issues: true
     issues_log: true

--- a/src/doctr_process/doctr_mod/config.yaml
+++ b/src/doctr_process/doctr_mod/config.yaml
@@ -25,6 +25,7 @@ page_fields_csv: true
 ticket_number_exceptions_csv: true
 manifest_number_exceptions_csv: true
 summary_report: true
+ticket_numbers_condensed_csv: true
 log_csv: true
 log_html: true
 sharepoint_config:

--- a/src/doctr_process/doctr_mod/docs/USER_GUIDE.md
+++ b/src/doctr_process/doctr_mod/docs/USER_GUIDE.md
@@ -132,6 +132,8 @@ sets the DPI of the saved PDF.
   - `combined_results.csv` – raw OCR results for every page
   - `combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag and
   **ROI Image Link** and **Manifest ROI Link** columns when the respective values are not `valid`
+  - `ticket_number/condensed_ticket_numbers.csv` – minimal ticket-number report
+    including job metadata and image links
   - `page_fields.csv` – per-page summary of all extracted fields with validation status
   - `ticket_number_exceptions.csv` – pages with no ticket number
   - `duplicate_ticket_exceptions.csv` – pages where the same vendor and ticket number combination appears more than once ("duplicate ticket pages") and any pages that produced no OCR text

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -24,3 +24,38 @@ def test_export_process_analysis(tmp_path):
     assert path.exists()
     df = pd.read_csv(path)
     assert 'ocr_time' in df.columns
+
+
+def test_condensed_ticket_report(tmp_path):
+    cfg = {'output_dir': str(tmp_path), 'ticket_numbers_condensed_csv': True}
+    rows = [{
+        'file': '24-105_2025-07-30_Class2_Podium_WM.pdf',
+        'page': 1,
+        'vendor': 'ACME',
+        'ticket_number': '123',
+        'manifest_number': '14123456',
+        'truck_number': 'TR1',
+        'exception_reason': None,
+        'image_path': 'img.png',
+        'roi_image_path': 'roi.png'
+    }]
+    reporting_utils.create_reports(rows, cfg)
+    path = tmp_path/'logs'/'ticket_number'/'condensed_ticket_numbers.csv'
+    assert path.exists()
+    df = pd.read_csv(path)
+    assert list(df.columns) == [
+        'JobID',
+        'Service Date',
+        'Material',
+        'Source',
+        'Destination',
+        'page',
+        'vendor',
+        'ticket_number',
+        'manifest_number',
+        'truck_number',
+        'exception_reason',
+        'image_path',
+        'roi_image_path'
+    ]
+    assert df.iloc[0]['JobID'] == '24-105'


### PR DESCRIPTION
## Summary
- add helper to parse job metadata from filenames
- create `ticket_number/condensed_ticket_numbers.csv` report with job fields and image links
- document new report and configuration flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689101e9974c83319a446d8e7293c538