### PR TITLE
feat: enhance ticket reporting

### DIFF
--- a/src/doctr_process/doctr_mod/config.yaml
+++ b/src/doctr_process/doctr_mod/config.yaml
@@ -14,7 +14,6 @@ output_csv: ./output/ocr/all_results.csv
 ticket_numbers_csv: ./output/ocr/combined_ticket_numbers.csv
 page_fields_csv: ./output/ocr/page_fields.csv
 manifest_number_exceptions_csv: ./output/logs/manifest_number/manifest_number_exceptions.csv
-output_images_dir: ./output/images/
 
 csv_filename: results.csv
 combined_pdf: true

--- a/src/doctr_process/doctr_mod/docs/USER_GUIDE.md
+++ b/src/doctr_process/doctr_mod/docs/USER_GUIDE.md
@@ -79,7 +79,6 @@ page_fields_csv: true
 ticket_number_exceptions_csv: true
 manifest_number_exceptions_csv: true
 summary_report: true
-output_images_dir: ./output/images/
 draw_roi: true
 orientation_check: tesseract  # tesseract, doctr, or none
 pdf_scale: 1.0  # scale vendor PDF pages (1.0 = original)

--- a/src/doctr_process/doctr_mod/docs/sample_config.yaml
+++ b/src/doctr_process/doctr_mod/docs/sample_config.yaml
@@ -7,7 +7,6 @@ page_fields_csv: true
 ticket_number_exceptions_csv: true
 manifest_number_exceptions_csv: true
 summary_report: true
-output_images_dir: ./output/images/
 draw_roi: true
 orientation_check: tesseract  # tesseract, doctr, or none
 pdf_scale: 1.0  # scale vendor PDFs (1.0 = original size)

--- a/src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
+++ b/src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
@@ -198,7 +198,24 @@ def process_file(
                 cfg,
                 vendor=display_name,
                 ticket_number=fields.get("ticket_number"),
+                roi_type="TicketNum_ROI",
             )
+            manifest_roi = (
+                extraction_rules.get(vendor_name, {})
+                .get("manifest_number", {})
+                .get("roi")
+            )
+            if manifest_roi:
+                row["manifest_roi_image_path"] = _save_roi_page_image(
+                    img,
+                    manifest_roi,
+                    pdf_path,
+                    i,
+                    cfg,
+                    vendor=display_name,
+                    ticket_number=fields.get("ticket_number"),
+                    roi_type="Manifest_ROI",
+                )
         rows.append(row)
         page_analysis.append(
             {
@@ -249,7 +266,7 @@ def save_page_image(
     Otherwise, the PDF stem is used as the base name.
     """
 
-    out_dir = Path(cfg.get("output_dir", "./outputs")) / "images"
+    out_dir = Path(cfg.get("output_dir", "./outputs")) / "images" / "page"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if ticket_number:
@@ -273,9 +290,10 @@ def _save_roi_page_image(
     cfg: dict,
     vendor: str | None = None,
     ticket_number: str | None = None,
+    roi_type: str = "TicketNum_ROI",
 ) -> str:
     """Draw ROI on ``img`` and save it to the images directory."""
-    out_dir = Path(cfg.get("output_images_dir", Path(cfg.get("output_dir", "./outputs")) / "images"))
+    out_dir = Path(cfg.get("output_dir", "./outputs")) / "images" / roi_type
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if ticket_number:

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -52,10 +52,13 @@ def test_condensed_ticket_report(tmp_path):
         'page',
         'vendor',
         'ticket_number',
+        'ticket_number_valid',
         'manifest_number',
+        'manifest_number_valid',
         'truck_number',
         'exception_reason',
         'image_path',
         'roi_image_path'
     ]
     assert df.iloc[0]['JobID'] == '24-105'
+    assert (tmp_path/'logs'/'ticket_number'/'condensed_ticket_numbers.xlsx').exists()


### PR DESCRIPTION
## Summary
- include validation columns and Excel report with hyperlinking in condensed ticket report
- save page and ROI images within output directory structure
- update tests and configs for new reporting and image paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68911562236c83319006924d54cafe06