### PR TITLE
Fix condensed ticket report hyperlinks and colour coding

### DIFF
--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -88,6 +88,12 @@ def test_condensed_ticket_report(tmp_path):
     assert img_cell.value == 'img.png'
     assert img_cell.hyperlink.target == 'img.png'
 
-    # Invalid ticket numbers should be highlighted
-    invalid_cell = ws.cell(row=3, column=8)
-    assert invalid_cell.fill.start_color.rgb.endswith('FFC7CE')
+    # Invalid ticket numbers should be highlighted and keep hyperlink
+    invalid_ticket = ws.cell(row=3, column=8)
+    assert invalid_ticket.hyperlink.target == 'roi2.png'
+    assert invalid_ticket.fill.start_color.rgb.endswith('FFC7CE')
+
+    # Invalid manifest numbers should also be highlighted and linked
+    invalid_manifest = ws.cell(row=3, column=10)
+    assert invalid_manifest.hyperlink.target == 'roi2.png'
+    assert invalid_manifest.fill.start_color.rgb.endswith('FFC7CE')


### PR DESCRIPTION
## Summary
- defer `filename_utils` import to avoid heavy optional dependencies during module import
- ensure condensed ticket Excel report hyperlinks use filenames and flag invalid numbers with red fill
- add tests covering hyperlink conversion and colour highlighting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bebe8c4883319a0ca1ebb310f489