### PR TITLE
Fix multiprocessing progress handling to avoid memoryview BufferError

### DIFF
--- a/src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
+++ b/src/doctr_process/doctr_mod/doctr_ocr_to_csv.py
@@ -462,13 +462,11 @@ def run_pipeline():
         from multiprocessing import Pool
 
         with Pool(cfg.get("num_workers", os.cpu_count())) as pool:
-            results = list(
-                tqdm(
-                    pool.imap(_proc, tasks),
-                    total=len(tasks),
-                    desc="Files",
-                )
-            )
+            results = []
+            with tqdm(total=len(tasks), desc="Files") as pbar:
+                for res in pool.imap(_proc, tasks):
+                    results.append(res)
+                    pbar.update()
     else:
         results = [
             _proc(t)


### PR DESCRIPTION
## Summary
- ensure tqdm progress bar is closed before Pool shutdown to prevent memoryview buffer errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6894c65fb4488331a16e4f2b81e66016