### PR TITLE
Handle extra fields when writing CSV output

### DIFF
--- a/src/doctr_process/output/csv_output.py
+++ b/src/doctr_process/output/csv_output.py
@@ -20,8 +20,17 @@ class CSVOutput(OutputHandler):
         path = os.path.join(out_dir, self.filename)
         if not rows:
             return
+        # Collect all field names across rows to avoid ``DictWriter`` errors when
+        # some rows contain additional keys. This preserves the order of keys as
+        # they appear and appends unseen keys as they are encountered.
+        fieldnames: List[str] = []
+        for row in rows:
+            for key in row.keys():
+                if key not in fieldnames:
+                    fieldnames.append(key)
+
         with open(path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(rows)
         logging.info("OCR text log saved: %s", path)

--- a/src/doctr_process/output/csv_output.py
+++ b/src/doctr_process/output/csv_output.py
@@ -15,14 +15,21 @@ class CSVOutput(OutputHandler):
         self.filename = filename
 
     def write(self, rows: List[Dict[str, Any]], cfg: dict) -> None:
+        """Write rows to a CSV file while preserving column order.
+
+        Keys from all rows are scanned in the order they are first encountered
+        to build the list of field names. This guarantees that columns in the
+        resulting CSV appear in the same order that keys are introduced across
+        the input rows, with new keys appended as they appear. It also prevents
+        ``DictWriter`` errors when some rows contain additional fields.
+        """
         out_dir = cfg.get("output_dir", "./outputs")
         os.makedirs(out_dir, exist_ok=True)
         path = os.path.join(out_dir, self.filename)
         if not rows:
             return
-        # Collect all field names across rows to avoid ``DictWriter`` errors when
-        # some rows contain additional keys. This preserves the order of keys as
-        # they appear and appends unseen keys as they are encountered.
+        # Collect all field names across rows in encounter order to avoid
+        # ``DictWriter`` errors and to maintain the column order guarantee.
         fieldnames: List[str] = []
         for row in rows:
             for key in row.keys():

--- a/tests/test_csv_output.py
+++ b/tests/test_csv_output.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Add project src directory to import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+# Import directly from the package to avoid stubs defined in ``conftest``
+from doctr_process.output.csv_output import CSVOutput
+
+
+def test_csv_output_handles_additional_fields(tmp_path):
+    rows = [
+        {'ticket_number': 'T1'},
+        {'ticket_number': 'T2', 'truck_number_roi_image_path': 'img.png'},
+    ]
+    cfg = {'output_dir': str(tmp_path)}
+    out = CSVOutput('results.csv')
+    out.write(rows, cfg)
+    df = pd.read_csv(tmp_path / 'results.csv')
+    assert 'ticket_number' in df.columns
+    assert 'truck_number_roi_image_path' in df.columns
+    assert df.loc[1, 'truck_number_roi_image_path'] == 'img.png'


### PR DESCRIPTION
## Summary
- Prevent `csv.DictWriter` failures by collecting all keys across rows when writing CSV output
- Add regression test ensuring CSVOutput handles rows with extra fields

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'ocr')
- `pytest tests/test_csv_output.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68950e57c0288331bdd72857d6cc54bb