### PR TITLE
Improve condensed ticket report links and color coding

### DIFF
--- a/src/doctr_process/ocr/reporting_utils.py
+++ b/src/doctr_process/ocr/reporting_utils.py
@@ -287,8 +287,17 @@ def create_reports(rows: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
 
             wb = load_workbook(excel_path)
             ws = wb.active
-            red = PatternFill(
+            invalid_ticket_fill = PatternFill(
                 start_color="FFC7CE", end_color="FFC7CE", fill_type="solid"
+            )
+            missing_ticket_fill = PatternFill(
+                start_color="FFEB9C", end_color="FFEB9C", fill_type="solid"
+            )
+            invalid_manifest_fill = PatternFill(
+                start_color="BDD7EE", end_color="BDD7EE", fill_type="solid"
+            )
+            missing_manifest_fill = PatternFill(
+                start_color="F4B084", end_color="F4B084", fill_type="solid"
             )
             t_col = columns.index("ticket_number") + 1
             m_col = columns.index("manifest_number") + 1
@@ -319,15 +328,25 @@ def create_reports(rows: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
                     fname = Path(roi).name
                     _set_cell(r, roi_col, fname, roi)
 
-                # Highlight invalid ticket numbers
+                # Highlight missing/invalid ticket numbers with distinct colours
+                ticket = rec.get("ticket_number")
                 if rec.get("ticket_number_valid") != "valid":
                     link = roi if roi else None
-                    _set_cell(r, t_col, rec.get("ticket_number"), link, red)
+                    value = ticket if ticket else "missing"
+                    fill = (
+                        invalid_ticket_fill if ticket else missing_ticket_fill
+                    )
+                    _set_cell(r, t_col, value, link, fill)
 
-                # Highlight invalid manifest numbers
+                # Highlight missing/invalid manifest numbers with distinct colours
+                manifest = rec.get("manifest_number")
                 if rec.get("manifest_number_valid") != "valid":
                     m_link = rec.get("manifest_roi_image_path") or roi
-                    _set_cell(r, m_col, rec.get("manifest_number"), m_link, red)
+                    value = manifest if manifest else "missing"
+                    fill = (
+                        invalid_manifest_fill if manifest else missing_manifest_fill
+                    )
+                    _set_cell(r, m_col, value, m_link, fill)
 
             wb.save(excel_path)
         except ImportError:

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -52,6 +52,18 @@ def test_condensed_ticket_report(tmp_path):
             'exception_reason': None,
             'image_path': 'img2.png',
             'roi_image_path': 'roi2.png'
+        },
+        # Row with missing ticket and manifest numbers
+        {
+            'file': '24-105_2025-07-30_Class2_Podium_WM.pdf',
+            'page': 3,
+            'vendor': 'ACME',
+            'ticket_number': '',
+            'manifest_number': '',
+            'truck_number': 'TR3',
+            'exception_reason': None,
+            'image_path': 'img3.png',
+            'roi_image_path': 'roi3.png'
         }
     ]
     reporting_utils.create_reports(rows, cfg)
@@ -97,7 +109,19 @@ def test_condensed_ticket_report(tmp_path):
     # Invalid manifest numbers should also be highlighted and linked
     invalid_manifest = ws.cell(row=3, column=10)
     assert invalid_manifest.hyperlink.target == 'roi2.png'
-    assert invalid_manifest.fill.start_color.rgb.endswith('FFC7CE')
+    assert invalid_manifest.fill.start_color.rgb.endswith('BDD7EE')
+
+    # Missing ticket numbers should show placeholder text with hyperlink
+    missing_ticket = ws.cell(row=4, column=8)
+    assert missing_ticket.value == 'missing'
+    assert missing_ticket.hyperlink.target == 'roi3.png'
+    assert missing_ticket.fill.start_color.rgb.endswith('FFEB9C')
+
+    # Missing manifest numbers should show placeholder text with hyperlink
+    missing_manifest = ws.cell(row=4, column=10)
+    assert missing_manifest.value == 'missing'
+    assert missing_manifest.hyperlink.target == 'roi3.png'
+    assert missing_manifest.fill.start_color.rgb.endswith('F4B084')
 
 
 def test_write_management_report(tmp_path):


### PR DESCRIPTION
## Summary
- avoid long file paths by inserting placeholder text for missing ticket and manifest numbers in condensed ticket reports
- color-code missing vs invalid ticket and manifest numbers with distinct highlights
- extend condensed ticket report tests for missing manifest/ticket cases

## Testing
- `PYTHONPATH=. pytest tests/test_reporting_utils.py` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_68966736b4688331ab1c513103c0e6c7