### PR TITLE
Yield ndarrays from image extractor

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@
 ## Architecture Overview
 
 - **Input:** PDF or directory of PDFs
-- **Image Extraction:** Converts each PDF page to PIL image
+- **Image Extraction:** Converts each PDF page to a ``numpy.ndarray``
 - **OCR:** Uses Doctr (torch) for page-level text detection
 - **Field Extraction:** Per-vendor logic, defined in YAML/CSV
 - **Validation:** Manifest and ticket numbers validated via regex and length logic
@@ -40,7 +40,7 @@
 ### Image & OCR
 
 - `extract_images_generator(filepath, poppler_path)`
-    - Converts PDF, TIFF, JPEG, PNG pages to images (yields PIL.Image)
+    - Converts PDF, TIFF, JPEG, PNG pages to images (yields ``numpy.ndarray``)
 - `ocr_predictor(pretrained=True)`
     - Loads Doctr OCR model
 

--- a/tests/test_image_cleanup.py
+++ b/tests/test_image_cleanup.py
@@ -64,8 +64,9 @@ def test_extract_images_generator_closes_files(ext, tmp_path):
     file_path = _create_sample(tmp_path / "sample", ext)
     imgs = list(extract_images_generator(str(file_path)))
     for img in imgs:
-        img.close()
-        assert getattr(img, "fp", None) is None
+        if hasattr(img, "close"):
+            img.close()
+            assert getattr(img, "fp", None) is None
     gc.collect()
     assert not _has_open_handle(file_path)
 
@@ -97,7 +98,8 @@ def test_multipage_tiff_processed(tmp_path, monkeypatch):
     imgs = list(extract_images_generator(str(file_path)))
     assert len(imgs) == 2
     for img in imgs:
-        img.close()
+        if hasattr(img, "close"):
+            img.close()
 
     cfg = {
         "ocr_engine": "tesseract",


### PR DESCRIPTION
## Summary
- Return numpy arrays from `extract_images_generator` and ensure PDF and TIFF pages are closed after conversion
- Allow `process_file` to accept arrays or PIL Images, converting arrays to PIL on demand
- Update developer docs and tests for ndarray image workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bebb3ffa88331b81bb4c02c8c264f