### PR TITLE
Fix doctr image handling for PIL inputs

### DIFF
--- a/src/doctr_process/ocr/ocr_engine.py
+++ b/src/doctr_process/ocr/ocr_engine.py
@@ -32,12 +32,22 @@ def get_engine(name: str):
         try:
             from doctr.models import ocr_predictor
             from doctr.io import DocumentFile
+            import numpy as np
+            from PIL import Image
 
             predictor = ocr_predictor(pretrained=True)
 
             def _run(img):
                 imgs = [img] if not isinstance(img, list) else img
-                doc = DocumentFile.from_images(imgs)
+                np_imgs = []
+                for im in imgs:
+                    if isinstance(im, np.ndarray):
+                        np_imgs.append(im)
+                    elif isinstance(im, Image.Image):
+                        np_imgs.append(np.array(im))
+                    else:
+                        np_imgs.append(im)
+                doc = DocumentFile.from_images(np_imgs)
                 res = predictor(doc)
                 pages = res.pages
                 texts = [page.render() for page in pages]

--- a/tests/test_ocr_engine.py
+++ b/tests/test_ocr_engine.py
@@ -3,6 +3,7 @@ from types import ModuleType
 
 import pytest
 from PIL import Image
+import numpy as np
 
 from doctr_process.ocr.ocr_engine import get_engine
 
@@ -113,6 +114,9 @@ def test_get_engine_with_image_objects(monkeypatch, engine_name, prefix):
         class DocumentFile:
             @staticmethod
             def from_images(imgs):
+                for im in imgs:
+                    if not isinstance(im, np.ndarray):
+                        raise TypeError("unsupported object type for argument 'file'")
                 return imgs
 
         class Page:


### PR DESCRIPTION
## Summary
- convert PIL images to NumPy arrays before feeding to doctr's `DocumentFile`
- test doctr engine against `DocumentFile` rejecting non-array inputs

## Testing
- `pytest tests/test_ocr_engine.py::test_get_engine_with_image_objects -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d14d15160833190ad1cfc6444d275