### PR TITLE
Fix handler factory signature causing list.get AttributeError

### DIFF
--- a/src/doctr_process/output/factory.py
+++ b/src/doctr_process/output/factory.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Sequence
 
 from .base import OutputHandler
 from .csv_output import CSVOutput
@@ -7,10 +7,9 @@ from .sharepoint_output import SharePointOutput
 from .vendor_doc_output import VendorDocumentOutput
 
 
-def create_handlers(cfg: dict, output_dir: str) -> List[OutputHandler]:
-    """Instantiate output handlers based on config."""
-    handlers = []
-    names = cfg.get("output_format", [])
+def create_handlers(names: Sequence[str], cfg: dict) -> List[OutputHandler]:
+    """Instantiate output handlers listed in ``names`` using ``cfg`` options."""
+    handlers: List[OutputHandler] = []
     for name in names:
         if name == "csv":
             handlers.append(CSVOutput(cfg.get("csv_filename", "results.csv")))


### PR DESCRIPTION
## Summary
- fix `create_handlers` to accept a list of handler names and config

## Testing
- `pytest` *(fails: tests/test_env_and_logging.py::test_logging_creates_runid_file, tests/test_image_cleanup.py::test_process_file_closes_images[tiff], tests/test_image_cleanup.py::test_process_file_closes_images[png], tests/test_image_cleanup.py::test_process_file_closes_images[jpg], tests/test_image_cleanup.py::test_process_file_closes_images[pdf], tests/test_image_cleanup.py::test_multipage_tiff_processed, tests/test_logging.py::test_logging_writes_files, tests/test_preflight.py::test_is_page_ocrable_rotated)*

------
https://chatgpt.com/codex/tasks/task_e_689f56fc01b083318038e98d9d8c4a41