### PR TITLE
Fix batch folder imports

### DIFF
--- a/src/doctr_process/pipeline.py
+++ b/src/doctr_process/pipeline.py
@@ -629,7 +629,7 @@ def _get_input_files(cfg: dict):
             # Collect all supported file types
             files = []
             for pattern in ["*.pdf", "*.tif", "*.tiff", "*.jpg", "*.jpeg", "*.png"]:
-                files.extend(path.glob(pattern))
+                files.extend(path.rglob(pattern))
 
             if not files:
                 logging.warning("No supported files found in directory: %s", input_dir)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -102,3 +102,25 @@ def test_run_pipeline_parallel(tmp_path, monkeypatch):
     par_rows, _ = _run_pipeline(tmp_path, monkeypatch, parallel=True)
     assert par_rows == seq_rows
     assert sorted(r["file"] for r in par_rows) == sorted(expected)
+
+
+def test_get_input_files_includes_nested(tmp_path):
+    input_dir = tmp_path / "inputs"
+    nested = input_dir / "nested" / "deeper"
+    nested.mkdir(parents=True)
+
+    top_pdf = input_dir / "top.pdf"
+    top_pdf.write_text("pdf")
+    nested_pdf = nested / "ticket.pdf"
+    nested_pdf.write_text("pdf")
+    nested_tif = nested / "image.tif"
+    nested_tif.write_text("tif")
+    ignored = nested / "ignore.txt"
+    ignored.write_text("noop")
+
+    cfg = {"batch_mode": True, "input_dir": str(input_dir)}
+
+    files = pipeline._get_input_files(cfg)
+
+    expected = {str(top_pdf), str(nested_pdf), str(nested_tif)}
+    assert set(files) == expected


### PR DESCRIPTION
## Summary
- update the batch file discovery to search nested folders recursively
- add regression coverage ensuring nested directories are picked up

## Testing
- pytest tests/test_run_pipeline.py::test_get_input_files_includes_nested -q

------
https://chatgpt.com/codex/tasks/task_e_68d6d11b93e083319b3f178c605544aa